### PR TITLE
fix: issue #10

### DIFF
--- a/src/breadcrumb/app-breadcrumb.service.ts
+++ b/src/breadcrumb/app-breadcrumb.service.ts
@@ -28,10 +28,12 @@ export class AppBreadcrumbService {
           if (route.outlet === 'primary') {
             const routeSnapshot = route.snapshot;
             url += '/' + routeSnapshot.url.map(segment => segment.path).join('/');
-            breadcrumbs.push({
-              label: route.snapshot.data,
-              url:   url
-            });
+            if (route.routeConfig.data && route.routeConfig.data.title) {
+              breadcrumbs.push({
+                label: route.snapshot.data,
+                url:   url
+              });
+            }
             currentRoute = route;
           }
         });


### PR DESCRIPTION
Potential fix to repeated breadcrumb from inherited data dictionary. Just checks if the original config has a `data.title` defined for the route hence a valid breadcrumb.