### PR TITLE
fix: should not throw errors when navItems are undefined

### DIFF
--- a/projects/coreui/angular/src/lib/sidebar/app-sidebar-nav.component.ts
+++ b/projects/coreui/angular/src/lib/sidebar/app-sidebar-nav.component.ts
@@ -77,7 +77,7 @@ export class AppSidebarNavComponent implements OnChanges {
   }
 
   public ngOnChanges(changes: SimpleChanges): void {
-    this.navItemsArray = JSON.parse(JSON.stringify(this.navItems));
+    this.navItemsArray = JSON.parse(JSON.stringify(this.navItems || []));
   }
 
   constructor() { }


### PR DESCRIPTION
I came across an esoteric error today after updating, with the message being about not being able to parse some JSON. I eventually tracked it down by monkey-patching `JSON.parse` and finding the error coming from the fact that my `navItems` property on my component was undefined at the point at which it was being run through the JSON.parse/JSON.stringify line that I've changed.
I'm assuming the introduction of the stringify/parse is to get a deep clone of the array -- the fix supplied would treat undefined items as if there are no items.