### PR TITLE
feat(sidebar): `minimized` state @Input/@Output

### DIFF
--- a/projects/coreui/angular/src/lib/sidebar/app-sidebar-minimizer.component.ts
+++ b/projects/coreui/angular/src/lib/sidebar/app-sidebar-minimizer.component.ts
@@ -1,33 +1,24 @@
-import {Component, ElementRef, HostBinding, HostListener, Inject, OnInit, Renderer2} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import { Component, HostBinding, HostListener, Optional } from '@angular/core';
+import { AppSidebarComponent } from './app-sidebar.component';
 
 @Component({
   selector: 'app-sidebar-minimizer, cui-sidebar-minimizer',
-  template: ``,
+  template: ``
 })
-export class AppSidebarMinimizerComponent implements OnInit {
+export class AppSidebarMinimizerComponent {
 
   @HostBinding('attr.role') role = 'button';
+  @HostBinding('class.sidebar-minimizer') _minimizer = true;
 
   @HostListener('click', ['$event'])
   toggleOpen($event: any) {
     $event.preventDefault();
-    const body = this.document.body;
-    body.classList.contains('sidebar-minimized') ?
-      this.renderer.removeClass(body, 'sidebar-minimized') :
-      this.renderer.addClass(body, 'sidebar-minimized');
-    body.classList.contains('brand-minimized') ?
-      this.renderer.removeClass(body, 'brand-minimized') :
-      this.renderer.addClass(body, 'brand-minimized');
+    this.sidebar.toggleMinimized();
   }
 
-  constructor(
-    @Inject(DOCUMENT) private document: any,
-    private renderer: Renderer2,
-    private hostElement: ElementRef
-  ) {
-    renderer.addClass(hostElement.nativeElement, 'sidebar-minimizer');
+  constructor(@Optional() private sidebar: AppSidebarComponent) {
+    if (!sidebar) {
+      throw Error(`AppSidebarMinimizer must be placed within a AppSidebar component.`);
+    }
   }
-
-  ngOnInit() {}
 }

--- a/projects/coreui/angular/src/lib/sidebar/app-sidebar.component.spec.ts
+++ b/projects/coreui/angular/src/lib/sidebar/app-sidebar.component.spec.ts
@@ -1,0 +1,50 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { AppSidebarComponent } from './app-sidebar.component';
+
+describe('AppSidebarComponent', () => {
+  let component: AppSidebarComponent;
+  let fixture: ComponentFixture<AppSidebarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AppSidebarComponent ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppSidebarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('has sidebar class', () => {
+    expect(fixture.nativeElement.classList.contains('sidebar')).toBeTruthy();
+  });
+
+  describe('minimized', () => {
+    it('updates document.body classes', () => {
+      component.minimized = true;
+      expect(document.body.classList.contains('sidebar-minimized')).toBeTruthy();
+      expect(document.body.classList.contains('brand-minimized')).toBeTruthy();
+
+      component.minimized = false;
+      expect(document.body.classList.contains('sidebar-minimized')).toBeFalsy();
+      expect(document.body.classList.contains('brand-minimized')).toBeFalsy();
+    });
+
+    it('emits only when value changes', async(() => {
+      spyOn(component.minimizedChange, 'emit');
+
+      component.minimized = true;
+      component.minimized = true;
+      component.minimized = false;
+
+      expect(component.minimizedChange.emit).toHaveBeenCalledTimes(2);
+    }));
+  });
+});


### PR DESCRIPTION
- When `minimized` input property is set from outside,  sidebar will properly switch it's state, eg:
  `[minimized]="sidebar.minimized$ | async"`
- It's possible to listen to `minimized` value changes,  eg. to persist in localStorage
  `[(minimized)]="minimized"` or
  `[minimized]="minimized$ | async" (minimizedChange)="minimized$.next($event)"`