### PR TITLE
fix: add missing AppSidebarNavComponent/AppSidebarMinimizer to public api

### DIFF
--- a/projects/coreui/angular/src/lib/sidebar/public_api.ts
+++ b/projects/coreui/angular/src/lib/sidebar/public_api.ts
@@ -1,4 +1,6 @@
 export { INavData } from './app-sidebar-nav';
 export { AppSidebarComponent } from './app-sidebar.component';
+export { AppSidebarNavComponent } from './app-sidebar-nav.component';
+export { AppSidebarMinimizerComponent } from './app-sidebar-minimizer.component';
 export { SidebarNavHelper } from './app-sidebar-nav.service';
 export { AppSidebarModule } from './app-sidebar.module';


### PR DESCRIPTION
exported AppSidebarNavComponent and AppSidebarMinimizer as part of the public api

Fixes #110