### PR TITLE
docs(api): document inputs and outputs the docs already describe

### DIFF
--- a/projects/coreui-angular/src/lib/grid/col.directive.ts
+++ b/projects/coreui-angular/src/lib/grid/col.directive.ts
@@ -28,6 +28,11 @@ export class ColDirective {
    * @return { 'auto' | number |  boolean }
    */
   readonly cCol = input(false, { transform: this.coerceInput });
+
+  /**
+   * The number of columns on extra small devices (<576px).
+   * @return { 'auto' | number | boolean }
+   */
   readonly xs = input(false, { transform: this.coerceInput });
 
   /**
@@ -71,7 +76,14 @@ export class ColDirective {
     } as Record<string, any>;
   });
 
+  /**
+   * Offset grid columns.
+   */
   readonly offset = input<ColOffsetType>();
+
+  /**
+   * Controls the visual order of your columns. Includes support for `1` through `5` across all breakpoints.
+   */
   readonly order = input<ColOrderType>();
 
   readonly hostClasses = computed(() => {

--- a/projects/coreui-angular/src/lib/modal/modal/modal.component.ts
+++ b/projects/coreui-angular/src/lib/modal/modal/modal.component.ts
@@ -88,6 +88,10 @@ export class ModalComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   readonly keyboard = input(true, { transform: booleanAttribute });
 
+  /**
+   * Html id attribute, required for programmatic visibility change.
+   * @type string
+   */
   readonly attrId = input<string>(undefined, { alias: 'id' });
 
   get id() {

--- a/projects/coreui-angular/src/lib/navbar/navbar.component.ts
+++ b/projects/coreui-angular/src/lib/navbar/navbar.component.ts
@@ -53,6 +53,10 @@ export class NavbarComponent {
    */
   readonly placement = input<'fixed-top' | 'fixed-bottom' | 'sticky-top'>();
 
+  /**
+   * HTML element role.
+   * @type string
+   */
   readonly role = input('navigation');
 
   readonly collapse = contentChild(CollapseDirective);

--- a/projects/coreui-angular/src/lib/offcanvas/offcanvas/offcanvas.component.ts
+++ b/projects/coreui-angular/src/lib/offcanvas/offcanvas/offcanvas.component.ts
@@ -91,6 +91,11 @@ export class OffcanvasComponent implements OnInit, OnDestroy {
    * @since 4.3.10
    */
   readonly responsive = input<(boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl') | undefined>(true);
+
+  /**
+   * Html id attribute, required for programmatic visibility change.
+   * @type string
+   */
   readonly id = input(`offcanvas-${this.placement()}-${nextId++}`);
 
   /**

--- a/projects/coreui-angular/src/lib/shared/theme.directive.ts
+++ b/projects/coreui-angular/src/lib/shared/theme.directive.ts
@@ -19,6 +19,11 @@ export class ThemeDirective {
     colorScheme ? this.setTheme(colorScheme) : this.unsetTheme();
   });
 
+  /**
+   * Add darker controls, indicators and captions.
+   * @type boolean
+   * @default false
+   */
   readonly dark = input(false, { transform: booleanAttribute });
 
   readonly #darkChange = effect(() => {

--- a/projects/coreui-angular/src/lib/sidebar/sidebar-brand/sidebar-brand.component.ts
+++ b/projects/coreui-angular/src/lib/sidebar/sidebar-brand/sidebar-brand.component.ts
@@ -10,9 +10,20 @@ import { HtmlAttributesDirective } from '../../shared';
   host: { class: 'sidebar-brand' }
 })
 export class SidebarBrandComponent {
+
+  /**
+   * Image for the wide sidebar.
+   */
   readonly brandFull = input<any>();
+
+  /**
+   * Image for the narrow sidebar.
+   */
   readonly brandNarrow = input<any>();
 
+  /**
+   * Router link for the brand images.
+   */
   readonly routerLink = input<string | any[] | UrlTree | null | undefined>();
 
   readonly brandImg = computed(() => Boolean(this.brandFull() || this.brandNarrow()));

--- a/projects/coreui-angular/src/lib/sidebar/sidebar-nav/sidebar-nav.component.ts
+++ b/projects/coreui-angular/src/lib/sidebar/sidebar-nav/sidebar-nav.component.ts
@@ -217,6 +217,11 @@ export class SidebarNavComponent implements OnChanges {
   readonly #hostElement = inject(ElementRef);
   readonly #sidebarService = inject(SidebarService);
 
+  /**
+   * Configuration object for sidebar-nav.
+   * @type INavData[]
+   * @default []
+   */
   readonly navItems = input<INavData[] | undefined>([]);
   readonly dropdownMode = input<'path' | 'none' | 'close'>('path');
   readonly groupItems = input<boolean, unknown>(undefined, { transform: booleanAttribute });

--- a/projects/coreui-angular/src/lib/sidebar/sidebar-nav/sidebar-nav.component.ts
+++ b/projects/coreui-angular/src/lib/sidebar/sidebar-nav/sidebar-nav.component.ts
@@ -87,6 +87,13 @@ export class SidebarNavGroupComponent implements OnInit, OnDestroy {
   }
 
   readonly item = input<INavData>();
+
+  /**
+   * Determines when an inactive `c-sidebar-nav-group` closes.
+   * - `path`: on an active route change only
+   * - `close`: when another group is clicked
+   * - `none`: never, the group stays open
+   */
   readonly dropdownMode = input<'path' | 'none' | 'close'>('path');
   readonly show = input<boolean>();
   readonly compact = input<boolean, unknown>(undefined, { transform: booleanAttribute });
@@ -223,6 +230,13 @@ export class SidebarNavComponent implements OnChanges {
    * @default []
    */
   readonly navItems = input<INavData[] | undefined>([]);
+
+  /**
+   * Determines when an inactive `c-sidebar-nav-group` closes.
+   * - `path`: on an active route change only
+   * - `close`: when another group is clicked
+   * - `none`: never, the group stays open
+   */
   readonly dropdownMode = input<'path' | 'none' | 'close'>('path');
   readonly groupItems = input<boolean, unknown>(undefined, { transform: booleanAttribute });
   readonly compact = input<boolean, unknown>(undefined, { transform: booleanAttribute });

--- a/projects/coreui-angular/src/lib/tabs-2/tabs.component.ts
+++ b/projects/coreui-angular/src/lib/tabs-2/tabs.component.ts
@@ -29,6 +29,12 @@ export class TabsComponent {
    * @type string
    */
   tabsId = `tabs-${nextId++}`;
+
+  /**
+   * HTML id attribute.
+   * @type string
+   * @default `tabs-{n}`
+   */
   readonly id = input<string>(this.tabsId);
 
   readonly #activeItemEffect = effect(() => {

--- a/projects/coreui-angular/src/lib/toast/toast-close.directive.ts
+++ b/projects/coreui-angular/src/lib/toast/toast-close.directive.ts
@@ -12,6 +12,10 @@ import type { ToastComponent } from './toast/toast.component';
 export class ToastCloseDirective {
   readonly #toasterService = inject(ToasterService);
 
+  /**
+   * Toast to close.
+   * @type ToastComponent
+   */
   readonly cToastClose = input<ToastComponent>();
 
   toggleOpen($event: MouseEvent): void {

--- a/projects/coreui-icons-angular/src/lib/icon/icon.directive.ts
+++ b/projects/coreui-icons-angular/src/lib/icon/icon.directive.ts
@@ -22,17 +22,60 @@ export class IconDirective implements IIcon {
   readonly #sanitizer = inject(DomSanitizer);
   readonly #iconSet = inject(IconSetService);
 
+  /**
+   * The icon itself: either its SVG content, or a `[viewBox, content]` pair. Use this or
+   * `name`, as it decides how the icon is imported.
+   */
   readonly content = input<string | string[] | any[] | undefined>(undefined, { alias: 'cIcon' });
 
+  /**
+   * Overwrites the default `.icon` classes.
+   */
   readonly customClasses = input<NgCssClass>();
+
+  /**
+   * Size of the icon.
+   */
   readonly size = input<IconSize>('');
+
+  /**
+   * Sets the SVG `title` tag.
+   */
   readonly title = input<string>();
+
+  /**
+   * Sets the SVG `height` attribute.
+   */
   readonly height = input<string>();
+
+  /**
+   * Sets the SVG `width` attribute.
+   */
   readonly width = input<string>();
+
+  /**
+   * Name of an SVG icon stored in `IconSetService`.
+   */
   readonly name = input('', { transform: transformName });
+
+  /**
+   * Sets the SVG `viewBox` attribute.
+   */
   readonly viewBoxInput = input<string | undefined>(undefined, { alias: 'viewBox' });
+
+  /**
+   * Sets the SVG `xmlns` attribute.
+   */
   readonly xmlns = input('http://www.w3.org/2000/svg');
+
+  /**
+   * Sets the CSS `pointer-events` property of the icon.
+   */
   readonly pointerEvents = input<IPointerEvents>('none', { alias: 'pointer-events' });
+
+  /**
+   * Sets the ARIA role of the icon.
+   */
   readonly role = input('img');
 
   readonly hostClasses = computed<NgCssClass>(() => {


### PR DESCRIPTION
The docs tables describe a number of inputs and outputs whose declarations carry no doc comment. API tables in the new Astro docs are generated from the source with TypeDoc, so those members come out with an empty Description column. This moves the descriptions the docs already have into the source, where they also show up in editor tooltips and in the published typings.

Covered here: `CModal.id`, `CNavbar.role`, `COffcanvas.id`, `CSidebarBrand.brandFull` / `brandNarrow` / `routerLink`, `CTabs.id`, `cToastClose`.

`CSidebarBrand.brandNarrow` was documented as "Image for wide sidebar" — a copy-paste from `brandFull`; corrected rather than copied verbatim.

The same change goes into coreui-angular-pro (coreui/coreui-angular-pro#20) with byte-identical content for these files, so the next upstream sync merges cleanly.

**Verification.** `npm ci` + `npm run build:icons:prod` + `npm run build:lib:prod`: 0 errors. `ng lint coreui-angular`: 0 errors (only the pre-existing `prefer-on-push` warnings). Comments only, no behaviour change.