### PR TITLE
feat(Nav): nav group, nav group items, nav title, enclosed variants

### DIFF
--- a/projects/coreui-angular/src/lib/nav/nav-group-items.component.scss
+++ b/projects/coreui-angular/src/lib/nav/nav-group-items.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/projects/coreui-angular/src/lib/nav/nav-group-items.component.spec.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-group-items.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef } from '@angular/core';
+
+import { NavGroupItemsComponent } from './nav-group-items.component';
+
+describe('NavGroupItemsComponent', () => {
+  let component: NavGroupItemsComponent;
+  let fixture: ComponentFixture<NavGroupItemsComponent>;
+  let componentRef: ComponentRef<NavGroupItemsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NavGroupItemsComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NavGroupItemsComponent);
+    await fixture.whenStable();
+
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have css classes', () => {
+    expect(fixture.nativeElement.classList.contains('nav-group-items')).toBe(true);
+  });
+
+  it('should have css classes for compact', () => {
+    expect(fixture.nativeElement.classList.contains('compact')).toBe(false);
+    componentRef.setInput('compact', true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('compact')).toBe(true);
+  });
+});

--- a/projects/coreui-angular/src/lib/nav/nav-group-items.component.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-group-items.component.ts
@@ -1,0 +1,26 @@
+import { booleanAttribute, Component, computed, input } from '@angular/core';
+import { BooleanInput } from '../coreui.types';
+
+@Component({
+  selector: 'c-nav-group-items',
+  template: '<ng-content />',
+  styleUrls: ['./nav-group-items.component.scss'],
+  host: { '[class]': 'hostClasses()' }
+})
+export class NavGroupItemsComponent {
+  static ngAcceptInputType_compact: BooleanInput;
+
+  /**
+   * Make nav group items more compact by cutting all `padding` in half.
+   * @returns boolean
+   * @default false
+   */
+  readonly compact = input(false, { transform: booleanAttribute });
+
+  readonly hostClasses = computed(() => {
+    return {
+      'nav-group-items': true,
+      compact: this.compact()
+    } as Record<string, boolean>;
+  });
+}

--- a/projects/coreui-angular/src/lib/nav/nav-group.component.html
+++ b/projects/coreui-angular/src/lib/nav/nav-group.component.html
@@ -1,0 +1,25 @@
+@if (toggler() || togglerTemplate()) {
+  <a
+    (click)="toggleGroup($event)"
+    [attr.aria-expanded]="visibleState()"
+    class="nav-link nav-group-toggle"
+    href
+  >
+    @if (togglerTemplate(); as template) {
+      <ng-container
+        *ngTemplateOutlet="template; context: { $implicit: visibleState(), visible: visibleState() }"
+      />
+    } @else {
+      {{ toggler() }}
+    }
+  </a>
+}
+<c-nav-group-items
+  (collapseChange)="onCollapseChange($event)"
+  [compact]="compact()"
+  [style.display]="display()"
+  [visible]="visibleState()"
+  cCollapse
+>
+  <ng-content />
+</c-nav-group-items>

--- a/projects/coreui-angular/src/lib/nav/nav-group.component.scss
+++ b/projects/coreui-angular/src/lib/nav/nav-group.component.scss
@@ -1,0 +1,5 @@
+:host {
+  display: list-item;
+  text-align: match-parent;
+  text-align: -webkit-match-parent;
+}

--- a/projects/coreui-angular/src/lib/nav/nav-group.component.spec.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-group.component.spec.ts
@@ -1,0 +1,141 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ComponentRef } from '@angular/core';
+
+import { NavGroupComponent } from './nav-group.component';
+import { NavGroupService } from './nav-group.service';
+
+@Component({
+  template: `
+    <c-nav-group toggler="A">
+      <c-nav-group toggler="A1" />
+    </c-nav-group>
+    <c-nav-group toggler="B" />
+  `,
+  imports: [NavGroupComponent],
+  providers: [NavGroupService]
+})
+class TestComponent {}
+
+describe('NavGroupComponent', () => {
+  let component: NavGroupComponent;
+  let fixture: ComponentFixture<NavGroupComponent>;
+  let componentRef: ComponentRef<NavGroupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NavGroupComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NavGroupComponent);
+    await fixture.whenStable();
+
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have css classes', () => {
+    expect(fixture.nativeElement.classList.contains('nav-group')).toBe(true);
+    expect(fixture.nativeElement.classList.contains('show')).toBe(false);
+  });
+
+  it('should render toggler', () => {
+    expect(fixture.nativeElement.querySelector('.nav-group-toggle')).toBeNull();
+    componentRef.setInput('toggler', 'anchorText');
+    fixture.detectChanges();
+    const toggler = fixture.nativeElement.querySelector('.nav-group-toggle');
+    expect(toggler.classList.contains('nav-link')).toBe(true);
+    expect(toggler.textContent.trim()).toBe('anchorText');
+    expect(toggler.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('should toggle its own visibility', () => {
+    componentRef.setInput('toggler', 'anchorText');
+    fixture.detectChanges();
+    const toggler = fixture.nativeElement.querySelector('.nav-group-toggle');
+
+    toggler.click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('show')).toBe(true);
+
+    toggler.click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('show')).toBe(false);
+  });
+
+  it('should emit visibleChange on toggle', () => {
+    const visibleChange = vi.fn();
+    componentRef.setInput('toggler', 'anchorText');
+    component.visibleChange.subscribe(visibleChange);
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.nav-group-toggle').click();
+    expect(visibleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('should follow the visible input', () => {
+    componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('show')).toBe(true);
+
+    componentRef.setInput('visible', false);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('show')).toBe(false);
+  });
+});
+
+describe('NavGroupComponent accordion', () => {
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('should collapse the sibling group on open', () => {
+    const groups = fixture.nativeElement.querySelectorAll('c-nav-group');
+    const [groupA, , groupB] = groups;
+    const togglerA = groupA.querySelector('.nav-group-toggle');
+    const togglerB = groupB.querySelector('.nav-group-toggle');
+
+    togglerA.click();
+    fixture.detectChanges();
+    expect(groupA.classList.contains('show')).toBe(true);
+    expect(groupB.classList.contains('show')).toBe(false);
+
+    togglerB.click();
+    fixture.detectChanges();
+    expect(groupA.classList.contains('show')).toBe(false);
+    expect(groupB.classList.contains('show')).toBe(true);
+  });
+
+  it('should restore the nested group state on reopen', () => {
+    const [groupA, groupA1] = fixture.nativeElement.querySelectorAll('c-nav-group');
+    const togglerA = groupA.querySelector('.nav-group-toggle');
+    const togglerA1 = groupA1.querySelector('.nav-group-toggle');
+
+    togglerA.click();
+    fixture.detectChanges();
+    togglerA1.click();
+    fixture.detectChanges();
+    expect(groupA1.classList.contains('show')).toBe(true);
+
+    togglerA.click();
+    fixture.detectChanges();
+    expect(groupA.classList.contains('show')).toBe(false);
+
+    togglerA.click();
+    fixture.detectChanges();
+    expect(groupA.classList.contains('show')).toBe(true);
+    expect(groupA1.classList.contains('show')).toBe(true);
+  });
+});

--- a/projects/coreui-angular/src/lib/nav/nav-group.component.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-group.component.ts
@@ -1,0 +1,137 @@
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  booleanAttribute,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+  TemplateRef,
+  untracked
+} from '@angular/core';
+
+import { CollapseDirective } from '../collapse';
+import { BooleanInput } from '../coreui.types';
+import { NavGroupItemsComponent } from './nav-group-items.component';
+import { NavGroupService } from './nav-group.service';
+
+let nextId = 0;
+
+@Component({
+  selector: 'c-nav-group',
+  templateUrl: './nav-group.component.html',
+  styleUrls: ['./nav-group.component.scss'],
+  imports: [CollapseDirective, NavGroupItemsComponent, NgTemplateOutlet],
+  providers: [NavGroupService],
+  host: { '[class]': 'hostClasses()' }
+})
+export class NavGroupComponent {
+  static ngAcceptInputType_compact: BooleanInput;
+  static ngAcceptInputType_visible: BooleanInput;
+
+  readonly #navGroupService = inject(NavGroupService);
+  readonly #parentNavGroupService = inject(NavGroupService, { optional: true, skipSelf: true });
+
+  readonly #id = `nav-group-${nextId++}`;
+
+  constructor() {
+    this.#navGroupService.openBranch = () => {
+      this.openBranch();
+    };
+  }
+
+  /**
+   * Make nav group items more compact by cutting all `padding` in half.
+   * @returns boolean
+   * @default false
+   */
+  readonly compact = input(false, { transform: booleanAttribute });
+
+  /**
+   * Set group toggler label.
+   * @returns string
+   */
+  readonly toggler = input<string>();
+
+  /**
+   * Template for the group toggler content, receives the visible state as `$implicit`.
+   * @returns TemplateRef
+   */
+  readonly togglerTemplate = input<TemplateRef<{ $implicit: boolean; visible: boolean }>>();
+
+  /**
+   * Show nav group items. Sets the initial state, and follows every later change.
+   * @returns boolean
+   */
+  readonly visible = input<boolean | undefined, unknown>(undefined, { transform: booleanAttribute });
+
+  /**
+   * Event emitted on visibility change.
+   * @returns boolean
+   */
+  readonly visibleChange = output<boolean>();
+
+  readonly #uncontrolledVisible = signal(false);
+
+  readonly display = signal<string | null>(null);
+
+  readonly visibleState = computed(() => {
+    const parent = this.#parentNavGroupService;
+    return parent ? parent.activeId() === this.#id : this.#uncontrolledVisible();
+  });
+
+  readonly hostClasses = computed(() => {
+    return {
+      'nav-group': true,
+      show: this.visibleState()
+    } as Record<string, boolean>;
+  });
+
+  readonly #visibleEffect = effect(() => {
+    const visible = this.visible();
+    if (visible === undefined) {
+      return;
+    }
+    untracked(() => {
+      this.#setVisible(visible);
+    });
+  });
+
+  toggleGroup(event: Event): void {
+    event.preventDefault();
+    const next = !this.visibleState();
+    this.#setVisible(next);
+    this.visibleChange.emit(next);
+  }
+
+  openBranch(): void {
+    const parent = this.#parentNavGroupService;
+    if (!parent) {
+      this.#uncontrolledVisible.set(true);
+      return;
+    }
+    parent.setActiveId(this.#id);
+    parent.openBranch();
+  }
+
+  onCollapseChange(state: string): void {
+    this.display.set(state === 'collapsed' || state === 'open' ? null : 'block');
+  }
+
+  #setVisible(visible: boolean): void {
+    const parent = this.#parentNavGroupService;
+    if (!parent) {
+      this.#uncontrolledVisible.set(visible);
+      return;
+    }
+    if (visible) {
+      parent.setActiveId(this.#id);
+      return;
+    }
+    if (parent.activeId() === this.#id) {
+      parent.setActiveId(undefined);
+    }
+  }
+}

--- a/projects/coreui-angular/src/lib/nav/nav-group.service.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-group.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable()
+export class NavGroupService {
+  /**
+   * Id of the open group at this level, `undefined` when none is open.
+   */
+  readonly activeId = signal<string | undefined>(undefined);
+
+  /**
+   * Opens the level owner within its own parent and cascades up to the root.
+   * Replaced by the owning `c-nav-group`; stays a no-op for the root level.
+   */
+  openBranch: () => void = () => undefined;
+
+  setActiveId(id: string | undefined): void {
+    this.activeId.set(id);
+  }
+}

--- a/projects/coreui-angular/src/lib/nav/nav-item.component.html
+++ b/projects/coreui-angular/src/lib/nav/nav-item.component.html
@@ -1,0 +1,17 @@
+@if (href()) {
+  <a
+    [active]="active()"
+    [attr.href]="href()"
+    [disabled]="disabled()"
+    [tabindex]="tabindex()"
+    cNavLink
+  >
+    <ng-container *ngTemplateOutlet="content" />
+  </a>
+} @else {
+  <ng-container *ngTemplateOutlet="content" />
+}
+
+<ng-template #content>
+  <ng-content />
+</ng-template>

--- a/projects/coreui-angular/src/lib/nav/nav-item.component.spec.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-item.component.spec.ts
@@ -1,10 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef } from '@angular/core';
 
 import { NavItemComponent } from './nav-item.component';
 
 describe('NavItemComponent', () => {
   let component: NavItemComponent;
   let fixture: ComponentFixture<NavItemComponent>;
+  let componentRef: ComponentRef<NavItemComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -15,6 +17,7 @@ describe('NavItemComponent', () => {
     await fixture.whenStable();
 
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
     fixture.detectChanges();
   });
 
@@ -24,5 +27,43 @@ describe('NavItemComponent', () => {
 
   it('should have css classes', () => {
     expect(fixture.nativeElement.classList.contains('nav-item')).toBe(true);
+  });
+
+  it('should not render nav link without href', () => {
+    expect(fixture.nativeElement.querySelector('.nav-link')).toBeNull();
+  });
+
+  it('should render nav link for href', () => {
+    componentRef.setInput('href', '/test');
+    fixture.detectChanges();
+    const link = fixture.nativeElement.querySelector('.nav-link');
+    expect(link.getAttribute('href')).toBe('/test');
+    expect(link.classList.contains('active')).toBe(false);
+    expect(link.classList.contains('disabled')).toBe(false);
+  });
+
+  it('should not set tabindex on the nav link when not given', () => {
+    componentRef.setInput('href', '/test');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.nav-link').getAttribute('tabindex')).toBeNull();
+  });
+
+  it('should pass tabindex to the nav link', () => {
+    componentRef.setInput('href', '/test');
+    componentRef.setInput('tabindex', 2);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.nav-link').getAttribute('tabindex')).toBe('2');
+  });
+
+  it('should pass active and disabled to the nav link', () => {
+    componentRef.setInput('href', '/test');
+    componentRef.setInput('active', true);
+    componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+    const link = fixture.nativeElement.querySelector('.nav-link');
+    expect(link.classList.contains('active')).toBe(true);
+    expect(link.classList.contains('disabled')).toBe(true);
+    expect(link.getAttribute('aria-current')).toBe('page');
+    expect(link.getAttribute('tabindex')).toBe('-1');
   });
 });

--- a/projects/coreui-angular/src/lib/nav/nav-item.component.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-item.component.ts
@@ -1,9 +1,44 @@
-import { Component } from '@angular/core';
+import { booleanAttribute, Component, input, numberAttribute } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+
+import { BooleanInput, NumberInput } from '../coreui.types';
+import { NavLinkDirective } from './nav-link.directive';
 
 @Component({
   selector: 'c-nav-item',
-  template: '<ng-content />',
+  templateUrl: './nav-item.component.html',
   styleUrls: ['./nav-item.component.scss'],
+  imports: [NavLinkDirective, NgTemplateOutlet],
   host: { class: 'nav-item' }
 })
-export class NavItemComponent {}
+export class NavItemComponent {
+  static ngAcceptInputType_active: BooleanInput;
+  static ngAcceptInputType_disabled: BooleanInput;
+  static ngAcceptInputType_tabindex: NumberInput;
+
+  /**
+   * Toggle the active state for the nav link rendered for `href`.
+   * @returns boolean
+   * @default undefined
+   */
+  readonly active = input<boolean | undefined, unknown>(undefined, { transform: booleanAttribute });
+
+  /**
+   * Set disabled attr for the nav link rendered for `href`.
+   * @returns boolean
+   * @default false
+   */
+  readonly disabled = input(false, { transform: booleanAttribute });
+
+  /**
+   * The href attribute of the nav link. Set it to render the nav link, otherwise the item projects its content as is.
+   * @returns string
+   */
+  readonly href = input<string>();
+
+  /**
+   * The tabindex attribute of the nav link rendered for `href`.
+   * @returns number | undefined
+   */
+  readonly tabindex = input(undefined, { transform: numberAttribute });
+}

--- a/projects/coreui-angular/src/lib/nav/nav-link.directive.spec.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-link.directive.spec.ts
@@ -3,6 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, ComponentRef, DebugElement, input } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
+import { NavGroupComponent } from './nav-group.component';
+
 @Component({
   template: '<a cNavLink [active]="active()" [disabled]="disabled()">test</a>',
   imports: [NavLinkDirective]
@@ -10,6 +12,22 @@ import { By } from '@angular/platform-browser';
 class TestComponent {
   readonly active = input(false);
   readonly disabled = input(false);
+}
+
+@Component({
+  template: '<button cNavLink [disabled]="disabled()">test</button>',
+  imports: [NavLinkDirective]
+})
+class TestButtonComponent {
+  readonly disabled = input(false);
+}
+
+@Component({
+  template: '<c-nav-group toggler="group"><a cNavLink [active]="active()">test</a></c-nav-group>',
+  imports: [NavGroupComponent, NavLinkDirective]
+})
+class TestNavGroupComponent {
+  readonly active = input(false);
 }
 
 describe('NavLinkDirective', () => {
@@ -31,10 +49,7 @@ describe('NavLinkDirective', () => {
   });
 
   it('should create an instance', () => {
-    TestBed.runInInjectionContext(() => {
-      const directive = new NavLinkDirective();
-      expect(directive).toBeTruthy();
-    });
+    expect(debugElement.injector.get(NavLinkDirective)).toBeTruthy();
   });
 
   it('should have css classes', () => {
@@ -72,14 +87,59 @@ describe('NavLinkDirective', () => {
     expect(debugElement.nativeElement.getAttribute('disabled')).toBeNull();
     expect(debugElement.nativeElement.getAttribute('aria-disabled')).not.toBeTruthy();
     expect(debugElement.nativeElement.getAttribute('tabindex')).not.toBe('-1');
-    expect(debugElement.nativeElement.style.cursor).toBe('pointer');
+    componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+    expect(debugElement.nativeElement.getAttribute('disabled')).toBeNull();
+    expect(debugElement.nativeElement.getAttribute('aria-disabled')).toBeTruthy();
+    expect(debugElement.nativeElement.getAttribute('tabindex')).toBe('-1');
+    componentRef.setInput('disabled', false);
+    fixture.detectChanges();
+  });
+});
+
+describe('NavLinkDirective on a button host', () => {
+  let fixture: ComponentFixture<TestButtonComponent>;
+  let componentRef: ComponentRef<TestButtonComponent>;
+  let debugElement: DebugElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestButtonComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestButtonComponent);
+    componentRef = fixture.componentRef;
+    debugElement = fixture.debugElement.query(By.directive(NavLinkDirective));
+    fixture.detectChanges();
+  });
+
+  it('should have disabled attr instead of aria-disabled', () => {
     componentRef.setInput('disabled', true);
     fixture.detectChanges();
     expect(debugElement.nativeElement.getAttribute('disabled')).not.toBeNull();
-    expect(debugElement.nativeElement.getAttribute('aria-disabled')).toBeTruthy();
-    expect(debugElement.nativeElement.getAttribute('tabindex')).toBe('-1');
-    expect(debugElement.nativeElement.style.cursor).not.toBe('pointer');
-    componentRef.setInput('disabled', false);
+    expect(debugElement.nativeElement.getAttribute('aria-disabled')).not.toBeTruthy();
+    expect(debugElement.nativeElement.getAttribute('tabindex')).not.toBe('-1');
+  });
+});
+
+describe('NavLinkDirective in a nav group', () => {
+  let fixture: ComponentFixture<TestNavGroupComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestNavGroupComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestNavGroupComponent);
     fixture.detectChanges();
+  });
+
+  it('should open the group for an active link', () => {
+    const group = fixture.nativeElement.querySelector('c-nav-group');
+    expect(group.classList.contains('show')).toBe(false);
+
+    fixture.componentRef.setInput('active', true);
+    fixture.detectChanges();
+    expect(group.classList.contains('show')).toBe(true);
   });
 });

--- a/projects/coreui-angular/src/lib/nav/nav-link.directive.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-link.directive.ts
@@ -1,5 +1,20 @@
-import { booleanAttribute, computed, Directive, effect, input, numberAttribute } from '@angular/core';
+import {
+  afterNextRender,
+  booleanAttribute,
+  computed,
+  Directive,
+  effect,
+  ElementRef,
+  inject,
+  input,
+  numberAttribute,
+  OnDestroy,
+  untracked
+} from '@angular/core';
 import { BooleanInput } from '../coreui.types';
+import { NavGroupService } from './nav-group.service';
+
+const DISABLED_ATTR_ELEMENTS = new Set(['button', 'fieldset', 'input', 'optgroup', 'option', 'select', 'textarea']);
 
 @Directive({
   selector: '[cNavLink]',
@@ -8,12 +23,24 @@ import { BooleanInput } from '../coreui.types';
     '[attr.aria-current]': 'ariaCurrent()',
     '[attr.aria-disabled]': 'ariaDisabled',
     '[attr.disabled]': 'attrDisabled',
-    '[attr.tabindex]': 'attrTabindex',
-    '[style.cursor]': 'styleCursor'
+    '[attr.tabindex]': 'attrTabindex'
   }
 })
-export class NavLinkDirective {
+export class NavLinkDirective implements OnDestroy {
   static ngAcceptInputType_disabled: BooleanInput;
+
+  readonly #hostElement = inject(ElementRef);
+  readonly #navGroupService = inject(NavGroupService, { optional: true });
+
+  #classObserver?: MutationObserver;
+
+  constructor() {
+    afterNextRender({
+      read: () => {
+        this.#observeActiveClass();
+      }
+    });
+  }
 
   /**
    * Sets .nav-link class to the host
@@ -49,14 +76,22 @@ export class NavLinkDirective {
   ariaDisabled: boolean | null = null;
   attrDisabled: boolean | string | null = null;
   attrTabindex: number | null = null;
-  styleCursor: 'pointer' | null = null;
 
   readonly #disabledEffect = effect(() => {
     const disabled = this.disabled();
-    this.ariaDisabled = disabled || null;
-    this.attrDisabled = disabled ? '' : null;
-    this.attrTabindex = disabled ? -1 : (this.tabindex() ?? null);
-    this.styleCursor = disabled ? null : 'pointer';
+    const tabindex = this.tabindex();
+    const disabledAttrElement = DISABLED_ATTR_ELEMENTS.has(this.#tagName);
+    this.ariaDisabled = (disabled && !disabledAttrElement) || null;
+    this.attrDisabled = disabled && disabledAttrElement ? '' : null;
+    this.attrTabindex = disabled && !disabledAttrElement ? -1 : (Number.isNaN(tabindex) ? null : (tabindex ?? null));
+  });
+
+  readonly #activeEffect = effect(() => {
+    if (this.active()) {
+      untracked(() => {
+        this.#navGroupService?.openBranch();
+      });
+    }
   });
 
   readonly hostClasses = computed(() => {
@@ -66,4 +101,34 @@ export class NavLinkDirective {
       active: this.active()
     } as Record<string, boolean>;
   });
+
+  get #tagName(): string {
+    return (this.#hostElement.nativeElement as HTMLElement).tagName.toLowerCase();
+  }
+
+  ngOnDestroy(): void {
+    this.#classObserver?.disconnect();
+  }
+
+  #observeActiveClass(): void {
+    const host: HTMLElement = this.#hostElement.nativeElement;
+
+    if (!this.#navGroupService) {
+      return;
+    }
+
+    let wasActive = host.classList.contains('active');
+    if (wasActive) {
+      this.#navGroupService.openBranch();
+    }
+
+    this.#classObserver = new MutationObserver(() => {
+      const active = host.classList.contains('active');
+      if (active && !wasActive) {
+        this.#navGroupService?.openBranch();
+      }
+      wasActive = active;
+    });
+    this.#classObserver.observe(host, { attributes: true, attributeFilter: ['class'] });
+  }
 }

--- a/projects/coreui-angular/src/lib/nav/nav-title.component.scss
+++ b/projects/coreui-angular/src/lib/nav/nav-title.component.scss
@@ -1,0 +1,5 @@
+:host {
+  display: list-item;
+  text-align: match-parent;
+  text-align: -webkit-match-parent;
+}

--- a/projects/coreui-angular/src/lib/nav/nav-title.component.spec.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-title.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NavTitleComponent } from './nav-title.component';
+
+describe('NavTitleComponent', () => {
+  let component: NavTitleComponent;
+  let fixture: ComponentFixture<NavTitleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NavTitleComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NavTitleComponent);
+    await fixture.whenStable();
+
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have css classes', () => {
+    expect(fixture.nativeElement.classList.contains('nav-title')).toBe(true);
+  });
+});

--- a/projects/coreui-angular/src/lib/nav/nav-title.component.ts
+++ b/projects/coreui-angular/src/lib/nav/nav-title.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'c-nav-title',
+  template: '<ng-content />',
+  styleUrls: ['./nav-title.component.scss'],
+  host: { class: 'nav-title' }
+})
+export class NavTitleComponent {}

--- a/projects/coreui-angular/src/lib/nav/nav.component.spec.ts
+++ b/projects/coreui-angular/src/lib/nav/nav.component.spec.ts
@@ -43,6 +43,13 @@ describe('NavComponent', () => {
     expect(fixture.nativeElement.classList.contains('nav-justified')).toBe(false);
   });
 
+  it('should have role attribute', () => {
+    expect(fixture.nativeElement.getAttribute('role')).toBe('navigation');
+    componentRef.setInput('role', 'tablist');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.getAttribute('role')).toBe('tablist');
+  });
+
   it('should have css classes for variant', () => {
     expect(fixture.nativeElement.classList.contains('nav-tabs')).toBe(false);
     expect(fixture.nativeElement.classList.contains('nav-pills')).toBe(false);
@@ -77,11 +84,24 @@ describe('NavComponent', () => {
     expect(fixture.nativeElement.classList.contains('nav-underline')).toBe(false);
     expect(fixture.nativeElement.classList.contains('nav-underline-border')).toBe(true);
 
+    componentRef.setInput('variant', 'enclosed');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('nav-enclosed')).toBe(true);
+    expect(fixture.nativeElement.classList.contains('nav-enclosed-pills')).toBe(false);
+    expect(fixture.nativeElement.classList.contains('nav-underline-border')).toBe(false);
+
+    componentRef.setInput('variant', 'enclosed-pills');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('nav-enclosed')).toBe(true);
+    expect(fixture.nativeElement.classList.contains('nav-enclosed-pills')).toBe(true);
+
     componentRef.setInput('variant', undefined);
     fixture.detectChanges();
     expect(fixture.nativeElement.classList.contains('nav-tabs')).toBe(false);
     expect(fixture.nativeElement.classList.contains('nav-pills')).toBe(false);
     expect(fixture.nativeElement.classList.contains('nav-underline')).toBe(false);
     expect(fixture.nativeElement.classList.contains('nav-underline-border')).toBe(false);
+    expect(fixture.nativeElement.classList.contains('nav-enclosed')).toBe(false);
+    expect(fixture.nativeElement.classList.contains('nav-enclosed-pills')).toBe(false);
   });
 });

--- a/projects/coreui-angular/src/lib/nav/nav.component.ts
+++ b/projects/coreui-angular/src/lib/nav/nav.component.ts
@@ -4,7 +4,7 @@ import { Component, computed, input } from '@angular/core';
   selector: 'c-nav',
   template: '<ng-content />',
   styleUrls: ['./nav.component.scss'],
-  host: { class: 'nav', '[class]': 'hostClasses()' }
+  host: { class: 'nav', '[class]': 'hostClasses()', '[attr.role]': 'role()' }
 })
 export class NavComponent {
   /**
@@ -14,10 +14,17 @@ export class NavComponent {
   readonly layout = input<'fill' | 'justified'>();
 
   /**
+   * Default role for nav.
+   * @returns string
+   * @default 'navigation'
+   */
+  readonly role = input('navigation');
+
+  /**
    * Set the nav variant to tabs or pills.
    * @default undefined
    */
-  readonly variant = input<'tabs' | 'pills' | 'underline' | 'underline-border' | ''>();
+  readonly variant = input<'enclosed' | 'enclosed-pills' | 'pills' | 'tabs' | 'underline' | 'underline-border'>();
 
   readonly hostClasses = computed(() => {
     const layout = this.layout();
@@ -25,6 +32,7 @@ export class NavComponent {
     return {
       nav: true,
       [`nav-${layout}`]: !!layout,
+      'nav-enclosed': variant === 'enclosed' || variant === 'enclosed-pills',
       [`nav-${variant}`]: !!variant
     } as Record<string, boolean>;
   });

--- a/projects/coreui-angular/src/lib/nav/nav.module.ts
+++ b/projects/coreui-angular/src/lib/nav/nav.module.ts
@@ -1,18 +1,27 @@
 import { NgModule } from '@angular/core';
 import { NavComponent } from './nav.component';
+import { NavGroupComponent } from './nav-group.component';
+import { NavGroupItemsComponent } from './nav-group-items.component';
 import { NavItemComponent } from './nav-item.component';
 import { NavLinkDirective } from './nav-link.directive';
+import { NavTitleComponent } from './nav-title.component';
 
 @NgModule({
   imports: [
     NavComponent,
+    NavGroupComponent,
+    NavGroupItemsComponent,
     NavItemComponent,
-    NavLinkDirective
+    NavLinkDirective,
+    NavTitleComponent
   ],
   exports: [
     NavComponent,
+    NavGroupComponent,
+    NavGroupItemsComponent,
     NavItemComponent,
-    NavLinkDirective
+    NavLinkDirective,
+    NavTitleComponent
   ]
 })
 export class NavModule {}

--- a/projects/coreui-angular/src/lib/nav/public_api.ts
+++ b/projects/coreui-angular/src/lib/nav/public_api.ts
@@ -1,4 +1,8 @@
 export { NavLinkDirective } from './nav-link.directive';
+export { NavGroupComponent } from './nav-group.component';
+export { NavGroupItemsComponent } from './nav-group-items.component';
+export { NavGroupService } from './nav-group.service';
 export { NavItemComponent } from './nav-item.component';
+export { NavTitleComponent } from './nav-title.component';
 export { NavComponent } from './nav.component';
 export { NavModule } from './nav.module';

--- a/projects/coreui-angular/src/lib/sidebar/sidebar-nav/sidebar-nav.component.spec.ts
+++ b/projects/coreui-angular/src/lib/sidebar/sidebar-nav/sidebar-nav.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SidebarNavComponent } from './sidebar-nav.component';
 import { SidebarNavHelper } from './sidebar-nav.service';
+import { NavGroupService } from '../../nav';
 // import { SidebarNavGroupComponent } from './sidebar-nav-group.component';
 
 describe('SidebarNavComponent', () => {
@@ -42,6 +43,10 @@ describe('SidebarNavComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should provide the nav group accordion level', () => {
+    expect(fixture.debugElement.injector.get(NavGroupService)).toBeTruthy();
   });
 
   it('should have css classes', () => {

--- a/projects/coreui-angular/src/lib/sidebar/sidebar-nav/sidebar-nav.component.ts
+++ b/projects/coreui-angular/src/lib/sidebar/sidebar-nav/sidebar-nav.component.ts
@@ -26,6 +26,7 @@ import { SidebarComponent } from '../sidebar/sidebar.component';
 import { INavData } from './sidebar-nav';
 import { SidebarNavHelper } from './sidebar-nav.service';
 import { SidebarNavGroupService } from './sidebar-nav-group.service';
+import { NavGroupService } from '../../nav';
 import { HtmlAttributesDirective } from '../../shared';
 import { SidebarNavIconPipe } from './sidebar-nav-icon.pipe';
 import { SidebarNavBadgePipe } from './sidebar-nav-badge.pipe';
@@ -228,7 +229,7 @@ export class SidebarNavGroupComponent implements OnInit, OnDestroy {
     '[attr.role]': 'role()'
   },
   changeDetection: ChangeDetectionStrategy.Eager,
-  providers: [SidebarNavGroupService]
+  providers: [NavGroupService, SidebarNavGroupService]
 })
 export class SidebarNavComponent implements OnChanges {
   readonly sidebar = inject(SidebarComponent, { optional: true });

--- a/projects/coreui-angular/src/lib/tabs-2/tabs-list/tabs-list.component.spec.ts
+++ b/projects/coreui-angular/src/lib/tabs-2/tabs-list/tabs-list.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef } from '@angular/core';
 
 import { TabsListComponent } from './tabs-list.component';
 import { TabsService } from '../tabs.service';
@@ -6,6 +7,7 @@ import { TabsService } from '../tabs.service';
 describe('TabsListComponent', () => {
   let component: TabsListComponent;
   let fixture: ComponentFixture<TabsListComponent>;
+  let componentRef: ComponentRef<TabsListComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -15,10 +17,30 @@ describe('TabsListComponent', () => {
 
     fixture = TestBed.createComponent(TabsListComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have css classes for variant', () => {
+    expect(fixture.nativeElement.classList.contains('nav')).toBe(true);
+
+    componentRef.setInput('variant', 'pills');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('nav-pills')).toBe(true);
+    expect(fixture.nativeElement.classList.contains('nav-enclosed')).toBe(false);
+
+    componentRef.setInput('variant', 'enclosed');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('nav-enclosed')).toBe(true);
+    expect(fixture.nativeElement.classList.contains('nav-enclosed-pills')).toBe(false);
+
+    componentRef.setInput('variant', 'enclosed-pills');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList.contains('nav-enclosed')).toBe(true);
+    expect(fixture.nativeElement.classList.contains('nav-enclosed-pills')).toBe(true);
   });
 });

--- a/projects/coreui-angular/src/lib/tabs-2/tabs-list/tabs-list.component.ts
+++ b/projects/coreui-angular/src/lib/tabs-2/tabs-list/tabs-list.component.ts
@@ -52,11 +52,13 @@ export class TabsListComponent {
   readonly layout: InputSignal<'fill' | 'justified' | undefined> = input();
 
   /**
-   * Set the variant to tabs, pills or underline.
-   * @returns 'pills' | 'tabs' | 'underline' | 'underline-border' | undefined
+   * Set the variant to tabs, pills, underline or enclosed.
+   * @returns 'enclosed' | 'enclosed-pills' | 'pills' | 'tabs' | 'underline' | 'underline-border' | undefined
    * @default undefined
    */
-  readonly variant: InputSignal<'pills' | 'tabs' | 'underline' | 'underline-border' | undefined> = input();
+  readonly variant: InputSignal<
+    'enclosed' | 'enclosed-pills' | 'pills' | 'tabs' | 'underline' | 'underline-border' | undefined
+  > = input();
 
   /**
    * Set the role to tab list.
@@ -71,6 +73,7 @@ export class TabsListComponent {
     return {
       nav: true,
       [`nav-${layout}`]: layout,
+      'nav-enclosed': variant === 'enclosed' || variant === 'enclosed-pills',
       [`nav-${variant}`]: variant
     } as Record<string, boolean>;
   });


### PR DESCRIPTION
Declarative nav building blocks, so a nav can be written in the template instead of only fed to `c-sidebar-nav` as data.

## What lands

- **`c-nav-group`** — `toggler` / `togglerTemplate`, `visible` + `visibleChange`, `compact`. Collapsing reuses `cCollapse`.
- **`c-nav-group-items`**, **`c-nav-title`**.
- **Accordion per level** via `NavGroupService`: `c-sidebar-nav` provides the top level, each group provides a level for its children. Only one group per level stays open; a collapsed group keeps the state of its nested groups.
- **`cNavLink` fixes** — `disabled` attribute only where the element actually has one (`button`, `input`, `select`, …); other hosts get `aria-disabled` + `tabindex="-1"`. Inline `cursor` dropped in favour of CSS. An unset numeric binding no longer writes `tabindex="NaN"`. An active link now opens every group above it (class changes included), so `routerLinkActive` reveals the current route.
- **`c-nav`** — `variant` accepts `enclosed` and `enclosed-pills` (the latter also adds `nav-enclosed`), empty-string variant dropped, `role` input defaulting to `navigation`.
- **`c-nav-item`** — with `href` it renders the `cNavLink` anchor and forwards `active`, `disabled`, `tabindex`; without `href` the content is projected as before.
- **`c-tabs-list`** — same `enclosed` / `enclosed-pills` variants.

## Verification

`ng lint coreui-angular` — 0 errors (11 pre-existing warnings, none in the touched files); `ng test coreui-angular` — 505 passed; `ng build coreui-angular` — clean.

Docs for the new components come from `coreui-angular-docs` (`feat/nav-group-components` there); the PRO port is the branch of the same name in `coreui-angular-pro`.